### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/2](https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/2)

To fix the problem, we need to use SQL parameterization instead of string concatenation to construct the SQL query. This can be achieved by using placeholders (`?`) in the SQL query and passing the user-provided data as arguments to the `Exec` method. This approach ensures that the data is properly escaped and prevents SQL injection.

**Steps to fix:**
1. Modify the `Update` method in the `Gallery` struct to use placeholders in the SQL query.
2. Pass the user-provided data as arguments to the `Exec` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
