### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/5](https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/5)

To fix the problem, we need to enable CSRF protection in the `WebSecurityConfig` class. This can be done by removing the call to `csrf().disable()` in the `configure` method of the `HttpSecurity` object. By doing this, we ensure that CSRF protection is enabled, which helps prevent CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
