### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token")
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/4](https://github.com/org-nsp-pacificoprestacion-poc/code-scanning-demo/security/code-scanning/4)

To fix the problem, we should avoid logging the sensitive information contained in the `authz` variable. Instead, we can log a generic message indicating that a token was received without including the actual token value. This way, we maintain the functionality of logging the event without exposing sensitive information.

We need to modify the logging statements on lines 644 and 663 to exclude the actual token and authorization header values. We will replace them with generic messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
